### PR TITLE
loadbalance: implement picker to route and balance reqs

### DIFF
--- a/internal/loadbalance/picker.go
+++ b/internal/loadbalance/picker.go
@@ -1,0 +1,74 @@
+package loadbalance
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
+)
+
+var _ base.PickerBuilder = (*Picker)(nil)
+
+// Picker handle the RPC balancing logic by
+// picking a server from the servers discovered
+// by the resolver to handel each RPC.
+type Picker struct {
+	mu        sync.RWMutex
+	leader    balancer.SubConn
+	followers []balancer.SubConn
+	current   uint64
+}
+
+// Build sets up a Picker using the map of sub connections given in buildInfo.
+func (p *Picker) Build(buildInfo base.PickerBuildInfo) balancer.Picker {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var followers []balancer.SubConn
+	for sc, scInfo := range buildInfo.ReadySCs {
+		if isLeader := scInfo.Address.Attributes.Value("is_leader").(bool); isLeader {
+			p.leader = sc
+			continue
+		}
+		followers = append(followers, sc)
+	}
+
+	p.followers = followers
+	return p
+}
+
+var _ balancer.Picker = (*Picker)(nil)
+
+// Pick gets info containing the RPC's name and context from gRPC to help the picker know
+// what subconnection to pick, and returns the subconnection to handle the call in the result.
+func (p *Picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	var result balancer.PickResult
+	if strings.Contains(info.FullMethodName, "Produce") || len(p.followers) == 0 {
+		result.SubConn = p.leader
+	} else if strings.Contains(info.FullMethodName, "Consume") {
+		result.SubConn = p.nextFollower()
+	}
+
+	if result.SubConn == nil {
+		return result, balancer.ErrNoSubConnAvailable
+	}
+
+	return result, nil
+}
+
+func (p *Picker) nextFollower() balancer.SubConn {
+	cur := atomic.AddUint64(&p.current, uint64(1))
+	len := uint64(len(p.followers))
+	idx := int(cur % len)
+
+	return p.followers[idx]
+}
+
+func init() {
+	balancer.Register(base.NewBalancerBuilder(Name, &Picker{}, base.Config{}))
+}

--- a/internal/loadbalance/picker_test.go
+++ b/internal/loadbalance/picker_test.go
@@ -1,0 +1,88 @@
+package loadbalance_test
+
+import (
+	"testing"
+
+	"github.com/julieta-311/proglog/internal/loadbalance"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/attributes"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
+	"google.golang.org/grpc/resolver"
+)
+
+func TestPickerNoSubConnAvailable(t *testing.T) {
+	picker := &loadbalance.Picker{}
+
+	for _, method := range []string{
+		"/log.vX.Log/Produce",
+		"/log.vX.Log/Consume",
+	} {
+		info := balancer.PickInfo{
+			FullMethodName: method,
+		}
+		result, err := picker.Pick(info)
+		require.Equal(t, balancer.ErrNoSubConnAvailable, err)
+		require.Nil(t, result.SubConn)
+	}
+}
+
+func TestPickerProducesToLeader(t *testing.T) {
+	picker, subConns := setupTest()
+
+	info := balancer.PickInfo{
+		FullMethodName: "/log.vX.Log/Produce",
+	}
+	for i := 0; i < 5; i++ {
+		gotPick, err := picker.Pick(info)
+		require.NoError(t, err)
+		require.Equal(t, subConns[0], gotPick.SubConn)
+	}
+}
+
+func TestPickerConsumesFromFollowers(t *testing.T) {
+	picker, subConns := setupTest()
+
+	info := balancer.PickInfo{
+		FullMethodName: "/log.vX.Log/Consume",
+	}
+	for i := 0; i < 5; i++ {
+		gotPick, err := picker.Pick(info)
+		require.NoError(t, err)
+		require.Equal(t, subConns[i%2+1], gotPick.SubConn)
+	}
+}
+
+func setupTest() (*loadbalance.Picker, []*subConn) {
+	var subConns []*subConn
+	buildInfo := base.PickerBuildInfo{
+		ReadySCs: map[balancer.SubConn]base.SubConnInfo{},
+	}
+
+	for i := 0; i < 3; i++ {
+		sc := &subConn{}
+		addr := resolver.Address{
+			Attributes: attributes.New("is_leader", i == 0),
+		}
+
+		sc.UpdateAddresses([]resolver.Address{addr})
+		buildInfo.ReadySCs[sc] = base.SubConnInfo{Address: addr}
+		subConns = append(subConns, sc)
+	}
+
+	picker := loadbalance.Picker{}
+	picker.Build(buildInfo)
+
+	return &picker, subConns
+}
+
+// subConn implements the balancer.SubConn interface.
+type subConn struct {
+	addrs []resolver.Address
+}
+
+func (s *subConn) UpdateAddresses(addrs []resolver.Address) {
+	s.addrs = addrs
+}
+
+func (s *subConn) Connect() {}


### PR DESCRIPTION
In the gRPC architecture, pickers handle the RPC balancing logic, implement a picker using a builder pattern.