### PR TITLE
Bump Go version to 1.26 and bump Github action versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,20 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache go deps
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashfiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           cache: true
-          go-version: 1.25
+          go-version: 1.26
         env:
           GOFLAGS: -mod=mod
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.25
+          go-version: 1.26
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup protoc
         run: sudo apt install -y protobuf-compiler
@@ -42,7 +42,7 @@ jobs:
             --proto_path=.
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           args: --enable lll
-          version: "v2.5.0"
+          version: "v2.12.2"

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install yamllint
         run: pip install yamllint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/julieta-311/proglog
 
-go 1.25.1
+go 1.26
 
 require (
 	github.com/casbin/casbin v1.9.1


### PR DESCRIPTION
Bump go and bump checkout, cache, setup-python, and golangci-lint-action).