### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/julieta-311/proglog/security/code-scanning/3](https://github.com/julieta-311/proglog/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root (applies to all jobs unless overridden) with least privilege required for this pipeline.  
For this workflow, the best minimal fix is:

- `contents: read` (needed for `actions/checkout` and reading repo content)

Edit **`.github/workflows/go.yml`** by inserting `permissions:` between the `on:` trigger section and `jobs:`. No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
